### PR TITLE
Rename initial-condition keyword `uλ` → `u0`

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -4,14 +4,14 @@ function TGV(L; Re=1e5, T=Float32, mem=Array)
     # Define vortex size, velocity, viscosity
     U = 1; ν = U*L/Re
     # Taylor-Green-Vortex initial velocity field
-    function uλ(i,xyz)
+    function u0(i,xyz)
         x,y,z = @. (xyz-1.5)*π/L                # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)*cos(z) # u_x
         i==2 && return  U*cos(x)*sin(y)*cos(z) # u_y
         return 0.                              # u_z
     end
     # Initialize simulation
-    return Simulation((L, L, L), (0, 0, 0), L; U, uλ, ν, T, mem)
+    return Simulation((L, L, L), (0, 0, 0), L; U, u0, ν, T, mem)
 end
 function testParticles(mem=Array,N=96,T=Float32)
     CUDA.allowscalar(false)

--- a/examples/ParticlePlot.jl
+++ b/examples/ParticlePlot.jl
@@ -4,13 +4,13 @@ function make_particleplot(; N=Int(1e4), life=UInt(255), name="particleplot.mp4"
                              U=1, L=64, T=Float32,
                              mem=CUDA.functional() ? CUDA.CuArray : Array)
     k = T(π/L)
-    function uλ(i,xy)
+    function u0(i,xy)
         x,y = @. (xy-1.5f0)*k            # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)  # u_x
         i==2 && return  U*cos(x)*sin(y)  # u_y
         zero(k)
     end
-    sim = Simulation((L,L),(0, 0), L; U, uλ, ν=L*U/1e3, T, mem)
+    sim = Simulation((L,L),(0, 0), L; U, u0, ν=L*U/1e3, T, mem)
 
     # Set up Particles and CPU visualization arrays
     p = Particles(N,sim.flow.σ;mem,life)

--- a/examples/PathlinePlot.jl
+++ b/examples/PathlinePlot.jl
@@ -2,15 +2,15 @@ using WaterLily,CUDA,Pathlines,GLMakie
 
 function make_pathplot(L=64,T=Float32, U=1,mem=Array)
     k = T(π/L)
-    function uλ(i,xy)
+    function u0(i,xy)
         x,y = @. (xy-1.5f0)*k            # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)  # u_x
         i==2 && return  U*cos(x)*sin(y)  # u_y
         zero(k)
     end
-    
+
     # Initialize simulation
-    sim = Simulation((L, L), (0, 0), L; U, uλ, ν=U*L/1e3, T, mem)
+    sim = Simulation((L, L), (0, 0), L; U, u0, ν=U*L/1e3, T, mem)
 
     # Initialize plot
     color = :black

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,13 +8,13 @@ import CUDA
 # Small 2D Taylor-Green vortex simulation (reused across testsets)
 function tgv_sim(N=32, T=Float32; mem=Array, Δt=0.25f0)
     k = T(2π/N)
-    function uλ(i,xy)
+    function u0(i,xy)
         x,y = @. (xy - T(1.5)) * k
         i==1 && return -sin(x)*cos(y)
         i==2 && return  cos(x)*sin(y)
         zero(T)
     end
-    Simulation((N,N), (0,0), N; uλ, ν=T(1e-4), T, mem, Δt)
+    Simulation((N,N), (0,0), N; u0, ν=T(1e-4), T, mem, Δt)
 end
 
 @testset "Particles" begin
@@ -78,15 +78,15 @@ end
 
     if CUDA.functional()
         @testset "GPU update!: particles stay in bounds" begin
-            # uλ must not capture Type{T} — use concrete Float32 literals for GPU isbits
+            # u0 must not capture Type{T} — use concrete Float32 literals for GPU isbits
             N = 32; k = Float32(2π/N)
-            function uλ_gpu(i,xy)
+            function u0_gpu(i,xy)
                 x,y = @. (xy - 1.5f0)*k
                 i==1 && return -sin(x)*cos(y)
                 i==2 && return  cos(x)*sin(y)
                 0.0f0
             end
-            sim = Simulation((N,N), (0,0), N; uλ=uλ_gpu, ν=1f-4, T=Float32, mem=CUDA.CuArray)
+            sim = Simulation((N,N), (0,0), N; u0=u0_gpu, ν=1f-4, T=Float32, mem=CUDA.CuArray)
             p = Particles(1024, sim.flow.p; life=UInt(50), mem=CUDA.CuArray)
 
             for _ in 1:20


### PR DESCRIPTION
Adapt to the new WaterLily initial condition keyword change https://github.com/WaterLily-jl/WaterLily.jl/pull/303. Note that users receive a deprecation warning when still using `uλ` instead of `u0`. The full deprecation is planned for WaterLily 2.0.